### PR TITLE
Fix keypoints out of the box

### DIFF
--- a/utils/loss.py
+++ b/utils/loss.py
@@ -148,7 +148,7 @@ class ComputeLoss:
                     d = (pkpt_x-tkpt[i][:,0::2])**2 + (pkpt_y-tkpt[i][:,1::2])**2
                     s = torch.prod(tbox[i][:,-2:], dim=1, keepdim=True)
                     kpt_loss_factor = (torch.sum(kpt_mask != 0) + torch.sum(kpt_mask == 0))/torch.sum(kpt_mask != 0)
-                    lkpt += kpt_loss_factor*((1 - torch.exp(-d/(s*(4*sigmas**2)+1e-9)))*kpt_mask).mean()
+                    lkpt += kpt_loss_factor*((1 - torch.exp(-d/(2*(s*sigmas)**2+1e-9)))*kpt_mask).mean()
                 # Objectness
                 tobj[b, a, gj, gi] = (1.0 - self.gr) + self.gr * iou.detach().clamp(0).type(tobj.dtype)  # iou ratio
 


### PR DESCRIPTION
I noticed that keypoints show anomalies only for small objects, so I thought that it has something to do with it. Turns out that loss function worked bad for this objects and not properly penalized them as mentioned here https://github.com/TexasInstruments/edgeai-yolov5/issues/10#issuecomment-1152877166 it differs from original paper .
From the beginning of the training this problems dissappear:
![image](https://user-images.githubusercontent.com/84590713/183277419-fbba39f7-2f84-441b-97b9-6877c35c196d.png)

I can later update my final results, but it seams to me, that i won't stumble upon this problem again.
